### PR TITLE
feat: 회칙·세칙 게시판 추가 (#27)

### DIFF
--- a/src/lib/rules/post.rule.ts
+++ b/src/lib/rules/post.rule.ts
@@ -9,6 +9,7 @@ export function canEditOrDeletePost(post: Post, user: User): boolean {
 }
 
 export function canCreatePost(post: PostCreate, user: User): boolean {
-	if (post.boardId === BoardId.Notice) return hasMinRole(user, UserGroup.Moderator);
+	if (post.boardId === BoardId.Notice || post.boardId === BoardId.Bylaw)
+		return hasMinRole(user, UserGroup.Moderator);
 	else return true;
 }

--- a/src/lib/types/board.type.ts
+++ b/src/lib/types/board.type.ts
@@ -1,6 +1,7 @@
 export const BoardId = {
 	Notice: 'notice',
-	Free: 'free'
+	Free: 'free',
+	Bylaw: 'bylaw'
 } as const;
 
 export type BoardId = (typeof BoardId)[keyof typeof BoardId];

--- a/src/params/board.ts
+++ b/src/params/board.ts
@@ -3,5 +3,5 @@ import type { ParamMatcher } from '@sveltejs/kit';
 import { BoardId } from '$lib/types/board.type.js';
 
 export const match = ((param: string): param is BoardId => {
-	return param === BoardId.Free || param === BoardId.Notice;
+	return param === BoardId.Free || param === BoardId.Notice || param === BoardId.Bylaw;
 }) satisfies ParamMatcher;

--- a/src/routes/_components/NavBar.svelte
+++ b/src/routes/_components/NavBar.svelte
@@ -32,6 +32,8 @@
 
 		<a href="/board/free">자유게시판</a>
 
+		<a href="/board/bylaw">회칙·세칙</a>
+
 		<a href="/review">강의평가</a>
 
 		<a href="/petition">청원</a>
@@ -99,6 +101,7 @@
 	>
 		<a href="/board/notice" onclick={closeMenu}>공지사항</a>
 		<a href="/board/free" onclick={closeMenu}>자유게시판</a>
+		<a href="/board/bylaw" onclick={closeMenu}>회칙·세칙</a>
 		<a href="/review" onclick={closeMenu}>강의평가</a>
 		<a href="/petition" onclick={closeMenu}>청원</a>
 		<hr />

--- a/src/routes/board/[boardId=board]/_components/BoardHeader.svelte
+++ b/src/routes/board/[boardId=board]/_components/BoardHeader.svelte
@@ -18,6 +18,8 @@
 		<h1>자유게시판</h1>
 	{:else if boardId === 'notice'}
 		<h1>공지사항</h1>
+	{:else if boardId === 'bylaw'}
+		<h1>회칙·세칙</h1>
 	{/if}
 
 	<div class="container">
@@ -25,8 +27,10 @@
 			<p>구성원들과 자유로운 대화를 나눠보세요</p>
 		{:else if boardId === 'notice'}
 			<p>학생회의 공지사항을 한눈에 확인하세요</p>
+		{:else if boardId === 'bylaw'}
+			<p>총학생회의 회칙과 세칙을 확인하세요</p>
 		{/if}
-		{#if pageType === 'list' && (boardId === 'free' || (boardId === 'notice' && hasMinRole(user, 'moderator')))}
+		{#if pageType === 'list' && (boardId === 'free' || ((boardId === 'notice' || boardId === 'bylaw') && hasMinRole(user, 'moderator')))}
 			<LinkButton href="/board/{boardId}/new">
 				<Pen size="1rem" />
 				<span>글쓰기</span>


### PR DESCRIPTION
## Summary
- 학생회장 요청으로 세칙/회칙 열람용 게시판 추가
- 기존 `Notice`/`Free` 게시판 패턴을 그대로 따라가서 새 boardId `bylaw` 한 종류 추가
- URL: `/board/bylaw`, 표시명: "회칙·세칙"
- 작성 권한: moderator 이상 (Notice rule 재사용)

## Changes
| 파일 | 변경 |
|---|---|
| `src/lib/types/board.type.ts` | `BoardId.Bylaw` 추가 |
| `src/params/board.ts` | matcher에 bylaw 허용 |
| `src/lib/rules/post.rule.ts` | `canCreatePost`에 bylaw → moderator 분기 추가 |
| `src/routes/board/[boardId=board]/_components/BoardHeader.svelte` | 제목/부제/글쓰기 버튼 권한 분기 추가 |
| `src/routes/_components/NavBar.svelte` | 데스크탑+모바일 메뉴에 링크 추가 |

5 files changed, 13 insertions(+), 4 deletions(-)

## Scope 제외 (추후)
- 카테고리 분류 (회칙 vs 세칙 등)
- 버전/개정 이력 관리
- PDF 첨부 전용 UI
- 홈페이지에 bylaw 글 표시

## Test plan
- [ ] `/board/bylaw` 접속 → 헤더 "회칙·세칙" 표시
- [ ] 비로그인(guest): 글쓰기 버튼 안 보임
- [ ] user: 글쓰기 버튼 안 보임 (moderator 미만)
- [ ] moderator 이상: 글쓰기 버튼 보임, 글 작성/수정/삭제 동작
- [ ] 데스크탑 NavBar에 "회칙·세칙" 링크 표시
- [ ] 모바일 햄버거 메뉴에 "회칙·세칙" 링크 표시
- [ ] `npm run check` 통과 ✓ (이미 확인)
- [ ] `npm run build` 통과 ✓ (이미 확인)

## Related
- Closes #27
- 별도 이슈로 분리: #28 (NavBar dev 모드 CSS specificity)