### PR TITLE
feat: 이수한 과목도 시간표에 담을 수 있도록 재수강 허용

### DIFF
--- a/src/lib/services/timetable.service.ts
+++ b/src/lib/services/timetable.service.ts
@@ -13,30 +13,7 @@ async function owned(id: string, user: User): Promise<Timetable> {
 	return timetable;
 }
 
-async function validateCompletedCourses(
-	courseIds: string[],
-	user: User,
-	completedCourseIds?: Set<string>
-) {
-	const completed =
-		completedCourseIds ??
-		new Set(
-			(await AcademicRepository.findCompletedDegreeCourses(user.id)).map((course) => course.code)
-		);
-	const alreadyCompleted = [...new Set(courseIds)].filter((courseId) => completed.has(courseId));
-	if (alreadyCompleted.length)
-		throw new AppError(
-			APP_ERROR.BAD_REQUEST,
-			`이미 이수한 과목은 시간표에 담을 수 없습니다: ${alreadyCompleted.join(', ')}`
-		);
-	return completed;
-}
-
-async function validateEspSequence(
-	courseIds: string[],
-	user: User,
-	completedCourseIds?: Set<string>
-) {
+async function validateEspSequence(courseIds: string[], user: User) {
 	if (!courseIds.length) return;
 	const profile = await AcademicRepository.findAcademicProfile(user.id);
 	if (!profile)
@@ -47,11 +24,9 @@ async function validateEspSequence(
 	const policy = await AcademicRepository.findGraduationPolicy(profile.admissionYear);
 	const sequence = policy?.rules.courseSequences?.find((item) => item.category === 'ESP');
 	if (!sequence) throw new AppError(APP_ERROR.INTERNAL, 'ESP 이수 순서 정책을 찾을 수 없습니다.');
-	const completedCourses =
-		completedCourseIds ??
-		new Set(
-			(await AcademicRepository.findCompletedDegreeCourses(user.id)).map((course) => course.code)
-		);
+	const completedCourses = new Set(
+		(await AcademicRepository.findCompletedDegreeCourses(user.id)).map((course) => course.code)
+	);
 	const progress = getCourseSequenceProgress(
 		sequence,
 		completedCourses,
@@ -92,7 +67,6 @@ export async function addOffering(id: string, offeringId: string, user: User) {
 	if (timetable.offerings.some((item) => item.id === offering.id)) return;
 	if (timetable.offerings.some((item) => item.courseId === offering.courseId))
 		throw new AppError(APP_ERROR.CONFLICT, '같은 과목의 다른 분반이 이미 들어 있습니다.');
-	const completedCourseIds = await validateCompletedCourses([offering.courseId], user);
 	if (offering.category === 'ESP')
 		await validateEspSequence(
 			[
@@ -101,8 +75,7 @@ export async function addOffering(id: string, offeringId: string, user: User) {
 					.map((item) => item.courseId),
 				offering.courseId
 			],
-			user,
-			completedCourseIds
+			user
 		);
 	const conflict = timetable.offerings.find((item) =>
 		item.meetings.some((a) => offering.meetings.some((b) => hasMeetingConflict(a, b)))
@@ -138,16 +111,11 @@ export async function copy(id: string, user: User) {
 
 export async function confirm(id: string, user: User) {
 	const timetable = await owned(id, user);
-	const completedCourseIds = await validateCompletedCourses(
-		timetable.offerings.map((offering) => offering.courseId),
-		user
-	);
 	await validateEspSequence(
 		timetable.offerings
 			.filter((offering) => offering.category === 'ESP')
 			.map((offering) => offering.courseId),
-		user,
-		completedCourseIds
+		user
 	);
 	await TimetableRepository.clearConfirmed(user.id, timetable.year, timetable.term);
 	return await TimetableRepository.updateTimetable(id, user.id, { isConfirmed: true });

--- a/src/lib/usecase/timetable.usecase.ts
+++ b/src/lib/usecase/timetable.usecase.ts
@@ -46,13 +46,18 @@ export async function getPage(year: number, term: number, user: User) {
 	const offeringRestrictions = Object.fromEntries(
 		offerings.flatMap((offering) => {
 			let reason: string | null = null;
-			if (completedCourseIds.has(offering.courseId)) reason = '이수 완료';
-			else if (offering.category === 'ESP' && !profile) reason = 'ESP 정보 필요';
+			if (offering.category === 'ESP' && !profile) reason = 'ESP 정보 필요';
 			else if (offering.category === 'ESP' && !espSequence) reason = 'ESP 정책 확인 필요';
 			else if (offering.category === 'ESP' && !availableEspCourseIds.has(offering.courseId))
 				reason = 'ESP 단계 제한';
 			return reason ? [[offering.id, reason]] : [];
 		})
+	);
+	/** 담는 것을 막지 않고 알려만 주는 정보 — 이수한 과목도 재수강으로 담을 수 있다. */
+	const offeringNotices = Object.fromEntries(
+		offerings.flatMap((offering) =>
+			completedCourseIds.has(offering.courseId) ? [[offering.id, '이수 완료']] : []
+		)
 	);
 	const baseDegreeProgress = policy
 		? calculateDegreeProgress(completedDegreeCourses, policy.rules, {
@@ -112,6 +117,7 @@ export async function getPage(year: number, term: number, user: User) {
 		timetableProgress,
 		competition,
 		offeringRestrictions,
+		offeringNotices,
 		canManageCatalog: hasCapability(user, 'course.manage')
 	};
 }

--- a/src/routes/timetable/+page.svelte
+++ b/src/routes/timetable/+page.svelte
@@ -670,6 +670,7 @@
 						offerings={data.offerings}
 						timetable={selected}
 						offeringRestrictions={data.offeringRestrictions}
+						offeringNotices={data.offeringNotices}
 						filter={searchFilter}
 						{busy}
 						{pendingEnhance}

--- a/src/routes/timetable/_components/CourseSearchPanel.svelte
+++ b/src/routes/timetable/_components/CourseSearchPanel.svelte
@@ -15,6 +15,7 @@
 		offerings: Offering[];
 		timetable: Pick<Timetable, 'id' | 'offerings'>;
 		offeringRestrictions: Record<string, string>;
+		offeringNotices: Record<string, string>;
 		filter: CourseSearchFilter;
 		busy: boolean;
 		pendingEnhance: SubmitFunction;
@@ -28,6 +29,7 @@
 		offerings,
 		timetable,
 		offeringRestrictions,
+		offeringNotices,
 		filter,
 		busy,
 		pendingEnhance,
@@ -103,10 +105,15 @@
 		if (catalogReason) return { label: catalogReason, order: 2 };
 		return null;
 	}
+	/** 담을 수는 있지만 알아두면 좋은 정보 (예: 이미 이수한 과목의 재수강). */
+	function offeringNotice(offering: Offering): string | null {
+		return offeringNotices[offering.id] ?? null;
+	}
 	function resultRank(offering: Offering): number {
 		if (selectedOfferingIds.has(offering.id)) return 0;
 		const restriction = offeringRestriction(offering, false);
-		return restriction ? restriction.order + 2 : 1;
+		if (restriction) return restriction.order + 3;
+		return offeringNotice(offering) ? 2 : 1;
 	}
 </script>
 
@@ -156,12 +163,14 @@
 			{#each filteredOfferings as offering (offering.id)}
 				{@const alreadyAdded = selectedOfferingIds.has(offering.id)}
 				{@const restriction = offeringRestriction(offering, alreadyAdded)}
+				{@const notice = offeringNotice(offering)}
 				<article class:added={alreadyAdded} class:unavailable={Boolean(restriction)}>
 					<i style={`background: ${courseColor(offering.category)}`}></i>
 					<div class="offering-copy">
 						<div class="offering-tags">
 							<span>{offering.category ?? '기타'}</span><span>{offering.courseId}</span>
-							{#if restriction}<span class="unavailable-label">{restriction.label}</span>{/if}
+							{#if restriction}<span class="unavailable-label">{restriction.label}</span>
+							{:else if notice}<span class="notice-label">{notice}</span>{/if}
 						</div>
 						<strong>
 							{offering.courseName}
@@ -364,6 +373,11 @@
 	.offering-tags .unavailable-label {
 		background: var(--error-bg);
 		color: var(--error-text);
+	}
+	// 차단이 아니라 안내이므로 경고색이 아닌 성공색으로 구분한다.
+	.offering-tags .notice-label {
+		background: var(--success-bg);
+		color: var(--success-text);
 	}
 	.offering-actions {
 		display: flex;


### PR DESCRIPTION
낙제한 과목만 재수강이 가능하고, 이수 완료(passed)한 과목은 시간표에 담을 수 없었다. 성적 재수강을 계획할 수 없는 문제.

- 서버: addOffering·confirm에서 throw하던 validateCompletedCourses 제거

- ESP 검증이 필요할 때만 이수 과목을 조회하도록 정리 (일반 과목은 조회 생략)

- 차단(offeringRestrictions)과 안내(offeringNotices)를 분리해 이수 완료 표시는 유지

- 이수 완료 뱃지를 성공색으로 바꾸고, 정렬은 일반 > 이수 완료 > 차단 순으로

졸업학점은 calculateDegreeProgress가 course.code로 중복 제거하므로 재수강을 담아도 부풀지 않는다.